### PR TITLE
Tightening code filters

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,8 +104,8 @@ jobs:
         # I can print them out in the jobs below.
         list-files: shell
         # For docs, I only care about all changes in the docs directory.
-        # For code, I care about added and modified files everywhere but
-        # nothing in the docs directory.
+        # For code, I care only about the .toml file and the two code
+        # directories, src and tests.
         filters: |
           docs:
             - added|modified|deleted: 'docs/**'
@@ -118,7 +118,7 @@ jobs:
         echo Code files: ${{steps.filter.outputs.code_files}}
     - name: "Changed Docs Files"
       run: |
-        echo Code files: ${{steps.filter.outputs.docs_files}}
+        echo Docs files: ${{steps.filter.outputs.docs_files}}
 
 
   #############################################################################

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,8 +110,9 @@ jobs:
           docs:
             - added|modified|deleted: 'docs/**'
           code:
-            - added|modified:'**'
-            - '!docs/**'
+            - modified:'pyproject.toml'
+            - added|modified|deleted: 'src/**'
+            - added|modified|deleted: 'tests/**'
     - name: "Changed Code Files"
       run: |
         echo Code files: ${{steps.filter.outputs.code_files}}
@@ -177,7 +178,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install .[dev]
     # The unique part of this job.
-    - name: "Test and Coverage"
+    - name: "Run Tests and Coverage"
       # Generate the coverage data for this operating system.
       # The default name for the file is ".coverage", which is the same for
       # all operating systems and makes combining them later a little hard.


### PR DESCRIPTION
The current CI.yml filters are working, but are too broad. I'm running the full test suite when changing workflows. I need to change the code filter to the following:

modified: 'pyproject.toml'
added|modified|deleted: 'src/'
added|modified|deleted: 'test/'

Closes #28.